### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -3,6 +3,9 @@ name: Deploy Prod
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   DeployInfra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nestordgs/nestordgs.com/security/code-scanning/6](https://github.com/nestordgs/nestordgs.com/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow does not interact with repository contents or other GitHub features using `GITHUB_TOKEN`, the permissions can be set to `contents: read` at the workflow level. This ensures that the workflow has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. If specific jobs require additional permissions, they can override the root-level permissions with their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
