### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   TestingInfra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nestordgs/nestordgs.com/security/code-scanning/5](https://github.com/nestordgs/nestordgs.com/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required. Since the workflow only involves checking out the repository, setting up Node.js, installing dependencies, and running tests, it does not require write permissions. The minimal required permission is `contents: read`. This will ensure that the `GITHUB_TOKEN` has only read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
