### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   DeployInfra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nestordgs/nestordgs.com/security/code-scanning/4](https://github.com/nestordgs/nestordgs.com/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow to define minimal permissions for the `GITHUB_TOKEN`. Since the workflow involves operations such as checking out the repository, installing dependencies, and deploying infrastructure, we will grant `contents: read` permission, which is sufficient for most CI workflows. If any specific job requires additional permissions, we will define them within the job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
