### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   DeployInfra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nestordgs/nestordgs.com/security/code-scanning/3](https://github.com/nestordgs/nestordgs.com/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily interacts with the repository contents and AWS resources, we will set the permissions to `contents: read` at the workflow level. This ensures that all jobs in the workflow have minimal permissions unless explicitly overridden. Additionally, we will review the specific steps in the workflow to confirm that no additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
