### PR TITLE
docs(readme): refresh repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# nestordgs.com
+
+Source code for my personal website and the AWS infrastructure that publishes it. This repository is split into a frontend application in `website/` and an AWS CDK application in `infra/`. The site itself presents my professional profile, experience timeline, contact channels, and a featured project, while the infrastructure provisions the static hosting and CDN layers used to deliver the production build.
+
+## Getting Started
+
+These instructions will get a local copy of the project running for development and testing. Deployment is handled either locally with AWS CDK or through the GitHub Actions workflows included in this repository.
+
+### Project Layout
+
+- `website/` contains the Vite + React frontend.
+- `infra/` contains the AWS CDK stack for S3, CloudFront, and the production domain setup.
+- `.github/workflows/` contains the CI and deployment pipelines for pull requests, development, and production.
+
+### Prerequisites
+
+You do not need every tool for every task, but this is the baseline setup used by the repo:
+
+- Node.js 20.x
+- npm
+- AWS CLI configured with credentials that can deploy CDK stacks if you plan to work on `infra/`
+- AWS CDK CLI if you want to deploy infrastructure from your machine
+- A Route 53 hosted zone if you want to reproduce the production custom-domain deployment
+
+### Installing
+
+Install dependencies for each package separately:
+
+```bash
+cd website
+npm ci
+```
+
+```bash
+cd infra
+npm ci
+```
+
+Run the website locally:
+
+```bash
+cd website
+npm start
+```
+
+The frontend dev server runs on [http://localhost:3000](http://localhost:3000).
+
+If you need to inspect the infrastructure template locally:
+
+```bash
+cd infra
+PROJECT_NAME=nestordgs ENVIRONMENT=dev npm run cdk -- synth
+```
+
+## Running the Tests
+
+Both packages have their own test commands, and the pull request workflow runs both before changes are merged into `main`.
+
+### Frontend Tests
+
+The frontend uses Vitest, React Testing Library, and Happy DOM.
+
+```bash
+cd website
+npm run test:ci
+```
+
+For watch mode during local development:
+
+```bash
+cd website
+npm test
+```
+
+### Infrastructure Tests
+
+The infrastructure package uses Jest with AWS CDK assertions to verify the synthesized stack.
+
+```bash
+cd infra
+npm test
+```
+
+## Deployment
+
+Deployment is split into infrastructure provisioning and static asset publishing.
+
+### Development
+
+Pushing to `main` triggers `.github/workflows/deploy_to_dev.yml`, which:
+
+1. Deploys the CDK stack to the development environment.
+2. Builds the frontend in `website/`.
+3. Reads the S3 bucket name and CloudFront distribution ID from CloudFormation outputs.
+4. Syncs `website/dist` to S3.
+5. Invalidates `/index.html` in CloudFront.
+
+### Production
+
+Production deployments are triggered manually through `.github/workflows/deploy_to_prod.yml`. The flow is the same as development, with two important differences:
+
+- The infrastructure stack configures the custom domain with Route 53 and ACM.
+- The frontend build can inject PostHog analytics keys through Vite environment variables.
+
+### GitHub Actions Secrets
+
+The workflows expect these secrets:
+
+| Secret | Used For |
+| --- | --- |
+| `AWS_ACCESS_KEY` | AWS authentication in GitHub Actions |
+| `AWS_SECRET_ACCESS_KEY` | AWS authentication in GitHub Actions |
+| `AWS_REGION` | Region for deployment and CloudFormation/AWS CLI lookups |
+| `PROJECT_NAME` | Prefix used when naming AWS resources |
+| `ENVIRONMENT` | Deploy target, typically `dev` or `prod` |
+| `HOSTED_ZONE_ID` | Required for production Route 53 integration |
+| `HOSTED_ZONE_NAME` | Required for the production root domain and ACM certificate |
+| `VITE_PUBLIC_POSTHOG_KEY` | Optional frontend analytics key for production builds |
+| `VITE_PUBLIC_POSTHOG_HOST` | Optional PostHog host override |
+
+## Built With
+
+- [React](https://react.dev/) for the frontend UI
+- [Vite](https://vite.dev/) for local development and production builds
+- [Tailwind CSS](https://tailwindcss.com/) for styling
+- [TypeScript](https://www.typescriptlang.org/) across both packages
+- [AWS CDK](https://aws.amazon.com/cdk/) for infrastructure as code
+- [GitHub Actions](https://github.com/features/actions) for CI and deployment automation
+- [i18next](https://www.i18next.com/) for bilingual site content
+
+## Contributing
+
+This repository is a personal website project. It is not set up for external contributions.
+
+## Versioning
+
+This project is maintained through the main Git history rather than a separate public release process.
+
+## Authors
+
+- Nestor Gutiérrez - [nestordgs](https://github.com/nestordgs)
+
+## Acknowledgments
+
+- README structure adapted from [PurpleBooth's README template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
+- AWS CDK, Vite, and React for the tooling that supports the project

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,14 +1,139 @@
-# Welcome to your CDK TypeScript project
+# Infrastructure
 
-This is a blank project for CDK development with TypeScript.
+AWS CDK application for the `nestordgs.com` website. This package provisions the static hosting infrastructure used by the frontend build: a private versioned S3 bucket, a CloudFront distribution, and, in production, the custom domain resources in Route 53 and ACM.
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+## Getting Started
 
-## Useful commands
+These instructions explain how to install dependencies, synthesize the stack, run tests, and deploy the infrastructure from this package.
 
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `cdk deploy`      deploy this stack to your default AWS account/region
-* `cdk diff`        compare deployed stack with current state
-* `cdk synth`       emits the synthesized CloudFormation template
+### What This Stack Creates
+
+- One private S3 bucket with versioning enabled and server-side encryption
+- One CloudFront distribution backed by that bucket through an Origin Access Identity
+- CloudFormation outputs for the bucket name and CloudFront distribution ID
+- In production only:
+  - A DNS-validated ACM certificate in `us-east-1`
+  - A Route 53 alias record pointing the root domain to CloudFront
+
+### Prerequisites
+
+- Node.js 20.x
+- npm
+- AWS CLI configured with credentials that can deploy CDK stacks
+- AWS CDK CLI available globally or through `npx`
+- A bootstrapped CDK environment in the AWS account/region where you plan to deploy
+- A Route 53 hosted zone for the production domain
+
+### Installing
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+The stack reads its configuration from environment variables:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PROJECT_NAME` | Yes | Prefix used for bucket and distribution resource names |
+| `ENVIRONMENT` | Yes | Deployment target, typically `dev` or `prod` |
+| `HOSTED_ZONE_ID` | Production only | Route 53 hosted zone ID for the root domain |
+| `HOSTED_ZONE_NAME` | Production only | Root domain name used by Route 53 and ACM |
+| `AWS_REGION` | Recommended | Region used by AWS CLI and GitHub Actions commands |
+
+For a development synth:
+
+```bash
+PROJECT_NAME=nestordgs ENVIRONMENT=dev npm run cdk -- synth
+```
+
+For a production synth:
+
+```bash
+PROJECT_NAME=nestordgs ENVIRONMENT=prod HOSTED_ZONE_ID=Z123456789 HOSTED_ZONE_NAME=example.com npm run cdk -- synth
+```
+
+## Running the Tests
+
+Infrastructure tests are written with Jest and AWS CDK assertions.
+
+```bash
+npm test
+```
+
+### What the Tests Cover
+
+The current test suite verifies that the synthesized template includes:
+
+- An S3 bucket
+- Bucket versioning
+- A CloudFront distribution
+
+### Coding Style Checks
+
+There is currently no dedicated lint script in this package. Validation here comes from TypeScript compilation, CDK synthesis, and the Jest assertion suite.
+
+## Deployment
+
+Local deployment uses the AWS account and region configured in your shell through the AWS CLI/CDK.
+
+If the target account and region have not been bootstrapped for CDK yet, run:
+
+```bash
+npx cdk bootstrap
+```
+
+Deploy to development:
+
+```bash
+PROJECT_NAME=nestordgs ENVIRONMENT=dev npm run cdk -- deploy --all --require-approval never
+```
+
+Deploy to production:
+
+```bash
+PROJECT_NAME=nestordgs ENVIRONMENT=prod HOSTED_ZONE_ID=Z123456789 HOSTED_ZONE_NAME=example.com npm run cdk -- deploy --all --require-approval never
+```
+
+### Notes About the Stack
+
+- The S3 bucket is private and accessed through CloudFront only.
+- The bucket uses `RemovalPolicy.RETAIN`, which is a safer default for website assets.
+- Production creates the certificate in `us-east-1`, which is required by CloudFront for custom domains.
+- The frontend deployment workflow reads the `websiteBucketName` and `cloudFrontDistId` outputs after this stack finishes.
+
+### Useful Commands
+
+- `npm run build` compiles TypeScript
+- `npm run watch` recompiles on file changes
+- `npm run test` runs the Jest suite
+- `npm run cdk -- synth` generates the CloudFormation template
+- `npm run cdk -- diff` compares the local stack with the deployed stack
+- `npm run cdk -- deploy --all --require-approval never` deploys the stack
+
+## Built With
+
+- [AWS CDK v2](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
+- [Amazon S3](https://aws.amazon.com/s3/)
+- [Amazon CloudFront](https://aws.amazon.com/cloudfront/)
+- [Amazon Route 53](https://aws.amazon.com/route53/)
+- [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/)
+- [Jest](https://jestjs.io/) with CDK assertions
+
+## Contributing
+
+This is infrastructure for a personal website and is not accepting external contributions.
+
+## Versioning
+
+This package follows the repository history instead of a separate release stream.
+
+## Authors
+
+- Nestor Gutiérrez - [nestordgs](https://github.com/nestordgs)
+
+## Acknowledgments
+
+- AWS CDK for the infrastructure abstraction
+- GitHub Actions workflows in the root repository for automating deployments

--- a/website/README.md
+++ b/website/README.md
@@ -1,46 +1,148 @@
-# Getting Started with Create React App
+# Website
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Frontend application for the `nestordgs.com` personal site. This package contains the public-facing portfolio UI, including the hero section, experience timeline, featured LiftWiz project, profile/toolkit section, bilingual copy, theme switching, and contact links.
 
-## Available Scripts
+## Getting Started
 
-In the project directory, you can run:
+These instructions explain how to install dependencies, run the site locally, execute the tests, and build the static files that are later uploaded by the deployment workflow.
 
-### `yarn start`
+### Main Features
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+- Single-page portfolio built with React and Vite
+- English and Spanish copy managed through `i18next`
+- Dark and light theme toggle
+- Responsive navigation for desktop and mobile
+- Experience timeline and consulting profile sections
+- Featured project showcase for LiftWiz
+- Optional PostHog analytics when public Vite variables are present
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+### Project Structure
 
-### `yarn test`
+- `src/components/` for the site sections and shared UI pieces
+- `src/translations/` for English and Spanish content plus translation context
+- `src/hooks/` for UI behavior like theme management
+- `public/` for static images and icons served directly by Vite
+- `design/` for source design assets used to create the site visuals
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+### Prerequisites
 
-### `yarn build`
+- Node.js 20.x
+- npm
+- Optional PostHog environment variables if you want analytics enabled during a build
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### Installing
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+Install dependencies:
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+```bash
+npm ci
+```
 
-### `yarn eject`
+Start the development server:
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+```bash
+npm start
+```
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+### Optional Environment Variables
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+These values are only needed when you want analytics enabled:
 
-## Learn More
+| Variable | Required | Description |
+| --- | --- | --- |
+| `VITE_PUBLIC_POSTHOG_KEY` | Optional | Public PostHog project key |
+| `VITE_PUBLIC_POSTHOG_HOST` | Optional | PostHog host override, defaults to `https://us.i.posthog.com` |
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+Example:
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+```bash
+VITE_PUBLIC_POSTHOG_KEY=phc_xxx VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com npm run build
+```
+
+## Running the Tests
+
+The frontend test suite uses Vitest, React Testing Library, and Happy DOM.
+
+Run the test runner in watch mode:
+
+```bash
+npm test
+```
+
+Run the CI-oriented test command with coverage:
+
+```bash
+npm run test:ci
+```
+
+### Break Down of the Tests
+
+The current tests focus on component rendering and UI behavior, including:
+
+- App rendering
+- Menu and header rendering
+- Experience section behavior
+- Language switch behavior
+- Theme hook behavior
+- Translation context and reducer behavior
+
+### Coding Style Checks
+
+There is currently no dedicated lint script in this package. The main validation mechanisms are the test suite and the production build.
+
+## Deployment
+
+Create a production build with:
+
+```bash
+npm run build
+```
+
+Preview the generated build locally:
+
+```bash
+npm run preview
+```
+
+The production build is written to `dist/`. The repository deployment workflows then:
+
+1. Deploy or update the infrastructure stack in `infra/`.
+2. Build this package.
+3. Upload `dist/` to the S3 bucket created by the CDK stack.
+4. Invalidate the CloudFront cache for `/index.html`.
+
+### Notes About Runtime Behavior
+
+- The app initializes PostHog only when `VITE_PUBLIC_POSTHOG_KEY` is defined.
+- The theme toggle persists the selected theme in `localStorage`.
+- The site content is bilingual, with English loaded by default and Spanish available through the language switch.
+
+## Built With
+
+- [React 18](https://react.dev/)
+- [Vite](https://vite.dev/)
+- [Tailwind CSS 4](https://tailwindcss.com/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [i18next](https://www.i18next.com/)
+- [Font Awesome](https://fontawesome.com/)
+- [PostHog](https://posthog.com/) for optional analytics
+- [Vitest](https://vitest.dev/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
+
+## Contributing
+
+This package is part of a personal website project and is not accepting external contributions.
+
+## Versioning
+
+The website is maintained directly through the repository history.
+
+## Authors
+
+- Nestor Gutiérrez - [nestordgs](https://github.com/nestordgs)
+
+## Acknowledgments
+
+- README structure adapted from [PurpleBooth's README template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
+- Vite, Tailwind CSS, and React for the frontend foundation


### PR DESCRIPTION
## Summary

This PR refreshes the documentation across the repository so the READMEs match the current codebase and deployment workflow.

## What Changed

- Replaced the root `README.md` with a full project overview, setup instructions, test commands, deployment flow, and repository structure
- Rewrote `infra/README.md` to document the AWS CDK stack, required environment variables, CDK bootstrap/deploy flow, and infrastructure test coverage
- Rewrote `website/README.md` to document the Vite + React frontend, main features, optional PostHog environment variables, build flow, and frontend test commands
- Removed the old boilerplate README content from the `infra` and `website` folders
- Clarified that this is a personal project and not intended for external contributions

## Testing

- Not run; documentation-only change
