### PR TITLE
chore(deps): update aws-cdk-lib and fast-uri versions

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "infra",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.253.1",
         "constructs": "^10.6.0",
+        "fast-uri": "^3.1.2",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -38,9 +40,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.9.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.9.0.tgz",
-      "integrity": "sha512-Ss7Af943iyyTABqeJS30LylmELpdpGgHzQP87KxO+HGPFIFDsoZymSuU1H5eQAcuuOvcfIPSKA62/lf274UB2A==",
+      "version": "53.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.22.0.tgz",
+      "integrity": "sha512-2GLhjjf7Db697rRyYt6rjN06fwbBIiewPo/jxSCyUN259ejF7NQQRwvrdAQb9Aq2jPaIIp1cfHSoEdXyA6Bb7Q==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1257,9 +1259,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.253.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
+      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1278,8 +1280,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -1300,7 +1302,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1315,26 +1317,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1441,7 +1424,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -2278,6 +2261,22 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",

--- a/infra/package.json
+++ b/infra/package.json
@@ -7,10 +7,12 @@
   "overrides": {
     "minimatch": "^10.2.1",
     "ajv": "^8.17.1",
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.5",
+    "fast-uri": "^3.1.2"
   },
   "scripts": {
     "build": "tsc",
+    "postinstall": "node scripts/patch-cdk-fast-uri.cjs",
     "watch": "tsc -w",
     "test": "jest",
     "test:watch": "jest --watchAll",
@@ -19,15 +21,16 @@
   "devDependencies": {
     "@types/jest": "^29.2.5",
     "@types/node": "^18.19.0",
+    "aws-cdk": "^2.1118.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.5",
-    "aws-cdk": "^2.1118.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0",
+    "fast-uri": "^3.1.2",
     "source-map-support": "^0.5.21"
   }
 }

--- a/infra/scripts/patch-cdk-fast-uri.cjs
+++ b/infra/scripts/patch-cdk-fast-uri.cjs
@@ -1,0 +1,38 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const root = path.resolve(__dirname, '..')
+const source = path.join(root, 'node_modules', 'fast-uri')
+const target = path.join(root, 'node_modules', 'aws-cdk-lib', 'node_modules', 'fast-uri')
+const minimumVersion = '3.1.2'
+
+function readPackageVersion (directory) {
+  const packagePath = path.join(directory, 'package.json')
+  return JSON.parse(fs.readFileSync(packagePath, 'utf8')).version
+}
+
+function isAtLeast (actual, minimum) {
+  const actualParts = actual.split('.').map(Number)
+  const minimumParts = minimum.split('.').map(Number)
+
+  for (let i = 0; i < minimumParts.length; i++) {
+    if ((actualParts[i] || 0) > minimumParts[i]) return true
+    if ((actualParts[i] || 0) < minimumParts[i]) return false
+  }
+
+  return true
+}
+
+if (!fs.existsSync(source) || !fs.existsSync(target)) {
+  process.exit(0)
+}
+
+const sourceVersion = readPackageVersion(source)
+if (!isAtLeast(sourceVersion, minimumVersion)) {
+  throw new Error(`fast-uri ${sourceVersion} is below the required patched version ${minimumVersion}`)
+}
+
+fs.rmSync(target, { recursive: true, force: true })
+fs.cpSync(source, target, { recursive: true })


### PR DESCRIPTION
- Bump aws-cdk-lib from 2.248.0 to 2.253.1
- Add fast-uri as a dependency with version 3.1.2
- Introduce a post-install script to ensure fast-uri is patched correctly

This update addresses compatibility and security improvements.